### PR TITLE
fix(grid): stale zarr handle + silent RuntimeWarning in sync_local/interpolate

### DIFF
--- a/src/fastmeteo/core/grid.py
+++ b/src/fastmeteo/core/grid.py
@@ -1,3 +1,4 @@
+import warnings
 from abc import abstractmethod
 from typing import Any
 
@@ -75,15 +76,19 @@ class Grid:
             selected = self.select_remote(hour)
 
             if selected.time.size == 0:
-                RuntimeWarning(f"data from {start} to {stop} is not available remotely")
+                warnings.warn(
+                    f"data from {start} to {stop} is not available remotely",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
             else:
                 selected.to_zarr(
                     self.local_store, mode="a", append_dim="time", consolidated=True
                 )
 
-        # close to ensure the write is complete
+        # close stale handle and re-open to include appended data
         local_dataset.close()
-        return local_dataset
+        return xr.open_zarr(self.local_store, consolidated=True)
 
     def interpolate(self, df: pd.DataFrame) -> pd.DataFrame:
         """Interpolate data on a grid."""
@@ -113,7 +118,11 @@ class Grid:
         )
 
         if data_cropped.time.size == 0:
-            RuntimeWarning(f"data from {start} to {stop} is not available.")
+            warnings.warn(
+                f"data from {start} to {stop} is not available.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
             return df
 
         coords = self.coords(df)

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1,0 +1,197 @@
+"""Tests for Grid base class — AXM-490 regression tests.
+
+Bug 1: sync_local() returns a stale zarr handle (opened before appends).
+Bug 2: RuntimeWarning(...) instantiated but never raised/warned.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import warnings
+from typing import Any, ClassVar
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from fastmeteo.core.grid import Grid
+
+
+class StubGrid(Grid):
+    """Minimal concrete Grid for testing sync_local / interpolate logic."""
+
+    features: ClassVar[list[str]] = ["temperature"]
+
+    def __init__(self, local_store: str) -> None:
+        self.local_store = local_store
+
+    def select_remote(self, hour: pd.DatetimeIndex) -> xr.Dataset:
+        """Return a 1-hour dataset with a 'temperature' variable."""
+        time = pd.DatetimeIndex([hour])
+        ds = xr.Dataset(
+            {
+                "temperature": (
+                    ["time", "latitude", "longitude"],
+                    np.full((1, 3, 3), 288.0),
+                )
+            },
+            coords={
+                "time": time,
+                "latitude": [39.0, 41.0, 43.0],
+                "longitude": [3.0, 5.0, 7.0],
+            },
+        )
+        # Explicit encoding so zarr append handles sub-day offsets correctly
+        ds.time.encoding["units"] = "hours since 2024-01-01"
+        ds.time.encoding["dtype"] = "int64"
+        return ds
+
+    def coords(self, flight: pd.DataFrame) -> dict[str, Any]:
+        return {
+            "time": ("points", pd.to_datetime(flight.timestamp).values),
+            "latitude": ("points", flight.latitude.values),
+            "longitude": ("points", (flight.longitude % 360).values),
+        }
+
+
+def _make_flight(
+    start: str = "2024-06-01T01:30:00",
+    stop: str = "2024-06-01T02:30:00",
+) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "timestamp": [start, stop],
+            "latitude": [40.0, 42.0],
+            "longitude": [4.0, 6.0],
+            "altitude": [30_000.0, 32_000.0],
+        }
+    )
+
+
+# ---------- Bug 1: stale zarr handle -----------------------------------
+
+
+class TestSyncLocalFreshHandle:
+    """sync_local must return a dataset that includes newly appended hours."""
+
+    def test_sync_local_returns_fresh_handle(self) -> None:
+        """Create zarr with 1 hour, then sync_local for a wider range.
+
+        The returned dataset must contain ALL hours — including those
+        appended during the sync, not just the initial one.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            grid = StubGrid(local_store=tmp + "/test.zarr")
+
+            # Seed the cache with hour 01:00
+            seed_hour = pd.Timestamp("2024-06-01 01:00")
+            init_ds = grid.select_remote(seed_hour.to_datetime64())
+            init_ds.to_zarr(grid.local_store, mode="w", consolidated=True)
+
+            # Ask sync_local for 01:00 → 03:00  (should append 02:00 and 03:00)
+            result = grid.sync_local(
+                start="2024-06-01 01:00",
+                stop="2024-06-01 03:00",
+            )
+
+            result_times = pd.DatetimeIndex(result.time.values)
+            assert pd.Timestamp("2024-06-01 02:00") in result_times, (
+                "sync_local returned stale handle — missing appended hour 02:00"
+            )
+            assert pd.Timestamp("2024-06-01 03:00") in result_times, (
+                "sync_local returned stale handle — missing appended hour 03:00"
+            )
+            result.close()
+
+
+# ---------- Bug 2: silent RuntimeWarning --------------------------------
+
+
+class TestRuntimeWarningRaised:
+    """RuntimeWarning must actually be emitted, not silently discarded."""
+
+    def test_sync_local_warns_on_missing_remote_data(self) -> None:
+        """When select_remote returns an empty dataset, a warning must fire."""
+        with tempfile.TemporaryDirectory() as tmp:
+            grid = StubGrid(local_store=tmp + "/test.zarr")
+
+            # Seed cache with hour 01:00
+            seed_hour = pd.Timestamp("2024-06-01 01:00")
+            init_ds = grid.select_remote(seed_hour.to_datetime64())
+            init_ds.to_zarr(grid.local_store, mode="w", consolidated=True)
+
+            # Make select_remote return empty for the missing hour
+            def _empty_remote(hour: Any) -> xr.Dataset:
+                dims = ["time", "latitude", "longitude"]
+                return xr.Dataset(
+                    {"temperature": (dims, np.empty((0, 3, 3)))},
+                    coords={
+                        "time": pd.DatetimeIndex(
+                            [], dtype="datetime64[ns]"
+                        ),
+                        "latitude": [39.0, 41.0, 43.0],
+                        "longitude": [3.0, 5.0, 7.0],
+                    },
+                )
+
+            with patch.object(grid, "select_remote", side_effect=_empty_remote):
+                with warnings.catch_warnings(record=True) as w:
+                    warnings.simplefilter("always")
+                    grid.sync_local(
+                        start="2024-06-01 02:00",
+                        stop="2024-06-01 02:00",
+                    )
+
+            runtime_warnings = [
+                x for x in w
+                if issubclass(x.category, RuntimeWarning)
+            ]
+            assert len(runtime_warnings) >= 1, (
+                "RuntimeWarning not emitted (missing warnings.warn)"
+            )
+
+    def test_interpolate_warns_on_empty_cropped_data(self) -> None:
+        """When data_cropped.time.size == 0, a warning must fire (not silent return)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            grid = StubGrid(local_store=tmp + "/test.zarr")
+
+            # Seed cache with hour 01:00 only
+            seed_hour = pd.Timestamp("2024-06-01 01:00")
+            init_ds = grid.select_remote(seed_hour.to_datetime64())
+            init_ds.to_zarr(grid.local_store, mode="w", consolidated=True)
+
+            # Request flight at 10:00 — completely outside cache
+            flight = _make_flight(
+                start="2024-06-01 10:30:00",
+                stop="2024-06-01 11:30:00",
+            )
+
+            # Make select_remote return empty so sync_local can't fill the gap
+            def _empty_remote(hour: Any) -> xr.Dataset:
+                dims = ["time", "latitude", "longitude"]
+                return xr.Dataset(
+                    {"temperature": (dims, np.empty((0, 3, 3)))},
+                    coords={
+                        "time": pd.DatetimeIndex(
+                            [], dtype="datetime64[ns]"
+                        ),
+                        "latitude": [39.0, 41.0, 43.0],
+                        "longitude": [3.0, 5.0, 7.0],
+                    },
+                )
+
+            with patch.object(grid, "select_remote", side_effect=_empty_remote):
+                with warnings.catch_warnings(record=True) as w:
+                    warnings.simplefilter("always")
+                    result = grid.interpolate(flight)
+
+            runtime_warnings = [
+                x for x in w
+                if issubclass(x.category, RuntimeWarning)
+            ]
+            assert len(runtime_warnings) >= 1, (
+                "RuntimeWarning not emitted (missing warnings.warn)"
+            )
+            # Should still return the dataframe (without ERA5 columns)
+            assert "temperature" not in result.columns


### PR DESCRIPTION
# fix(grid): stale zarr handle + silent RuntimeWarning in `sync_local` / `interpolate`

## Summary

This PR fixes two bugs in `Grid.sync_local()` and `Grid.interpolate()` (`src/fastmeteo/core/grid.py`) that cause ERA5 weather enrichment to silently return incomplete data when processing flights whose time range extends beyond the local zarr cache.

## Bug 1 — Stale zarr handle (`sync_local`)

**Root cause**: `sync_local()` opens the zarr store at the beginning of the method (via `get_local()`), then appends new hours to disk in a loop, but returns the **original** (pre-append) xarray Dataset handle. Since `xr.open_zarr()` reads the store metadata at open time, the returned dataset does not reflect newly appended time slices.

**Impact**: `interpolate()` receives a dataset missing the hours it just requested. `data_cropped.time.size == 0`, and the flight is returned without ERA5 columns.

**Before** (lines 84–86):
```python
local_dataset.close()
return local_dataset  # ← stale handle, doesn't see appended data
```

**After**:
```python
local_dataset.close()
return xr.open_zarr(self.local_store, consolidated=True)  # fresh handle
```

## Bug 2 — Silent `RuntimeWarning` (lines 78, 116)

**Root cause**: `RuntimeWarning(...)` is instantiated as a Python object but never passed to `raise` or `warnings.warn()`. The warning is immediately garbage-collected — failures are completely invisible.

**Impact**: When remote data is unavailable or the local cache doesn't cover the requested time range, no error or warning is emitted. The caller silently receives a DataFrame without ERA5 columns.

**Before** (line 78, same pattern at line 116):
```python
RuntimeWarning(f"data from {start} to {stop} is not available remotely")  # no-op
```

**After**:
```python
warnings.warn(
    f"data from {start} to {stop} is not available remotely",
    RuntimeWarning,
    stacklevel=2,
)
```

## How to reproduce

```python
import tempfile
import numpy as np
import pandas as pd
import xarray as xr
from fastmeteo.core.grid import Grid

# 1. Create a minimal Grid subclass
# 2. Seed zarr cache with hour 01:00
# 3. Call sync_local(start="01:00", stop="03:00")
# 4. Inspect returned dataset — only contains 01:00 (missing 02:00, 03:00)
# 5. No warning is emitted despite incomplete data
```

Full reproduction is in the test file: `tests/test_grid.py`

## Tests added

| Test | Bug | Assertion |
|---|---|---|
| `test_sync_local_returns_fresh_handle` | #1 | Returned dataset includes all appended hours |
| `test_sync_local_warns_on_missing_remote_data` | #2 | `RuntimeWarning` is emitted when remote returns empty |
| `test_interpolate_warns_on_empty_cropped_data` | #2 | `RuntimeWarning` is emitted when cropped data is empty |

```
$ uv run pytest tests/test_grid.py -v
tests/test_grid.py::TestSyncLocalFreshHandle::test_sync_local_returns_fresh_handle PASSED
tests/test_grid.py::TestRuntimeWarningRaised::test_sync_local_warns_on_missing_remote_data PASSED
tests/test_grid.py::TestRuntimeWarningRaised::test_interpolate_warns_on_empty_cropped_data PASSED

3 passed in 0.82s
```

## Environment

- Python 3.12.12
- fastmeteo 1.1.0 (current `main`)
- xarray 2025.3.1, zarr 2.18.7
- macOS 15 (arm64)

## Files changed

| File | Change |
|---|---|
| `src/fastmeteo/core/grid.py` | `import warnings`, fix stale handle (re-open zarr), fix `RuntimeWarning` → `warnings.warn()` |
| `tests/test_grid.py` | **New** — 3 regression tests with `StubGrid` subclass |
